### PR TITLE
Added ability to publish to named exchanges

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -146,14 +146,22 @@ var checkRpc = (queue, msg, options) => {
       options.correlationId = corrId;
       options.replyTo = amqpRPCQueues[queue].queue;
 
-      amqpChannel.sendToQueue(queue, msg, options);
+      if (!options.exchange) {
+        amqpChannel.sendToQueue(queue, msg, options);
+      } else {
+        amqpChannel.publish(options.exchange, queue, msg, options);
+      }
 
       amqpRPCQueues[queue][corrId] = Promise.defer();
       return amqpRPCQueues[queue][corrId].promise;
     });
   }
 
-  return amqpChannel.sendToQueue(queue, msg, options);
+  if (!options.exchange) {
+    return amqpChannel.sendToQueue(queue, msg, options);
+  } else {
+    return amqpChannel.publish(options.exchange, queue, msg, options);
+  }
 };
 
 var produce = (queue, msg, options) => {
@@ -178,7 +186,16 @@ var produce = (queue, msg, options) => {
   });
 };
 
+var publish = function (exchange, routingKey, msg, options) {
+  options = options || {};
+  options.exchange = exchange;
+  return produce(routingKey, msg, options);
+};
+
 module.exports = (config) => {
   amqpConfig = config;
-  return { produce: produce };
+  return {
+    produce: produce,
+    publish: publish
+  };
 };


### PR DESCRIPTION
This will allow to publish to named exchanges, not to queues only:
`producer.publish(exchange, routingKey, request, { rpc: true })`
