### PR TITLE
v2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 [![npm](https://nodei.co/npm/bunnymq.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/bunnymq/)
 
 ## Features
-- Consumer
-- Producer
-- RPC
+- Subscriber (consumer)
+- Publisher (producer)
+- RPC (get answers from subscriber automatically)
 - Auto connect/reconnect/queue messages
-- Handle errors / requeing
-- Messages types caring using AMQP headers for content type
-- Connexions are handled for you: only 1/host, no matter how much you require BunnyMQ
+- Handle errors / requeing when message callback fails
+- Messages types caring using AMQP headers for content type (send as objects and receive as objects)
 
 ## Installation
+**bunnymq requires nodejs 6 or harmony flags!** because it uses es6 features outside strict mode.
 ```
 npm install bunnymq
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunnymq",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "BunnyMq is a RabbitMq wrapper",
   "keywords": [
     "rabbitmq",

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -22,7 +22,7 @@ function getConnection() {
   //prepare the connection internal object, and reset channel if connection has been closed
   connection = connections[url] = { conn: null, channel: null };
   connection.conn = amqp.connect(url, { clientProperties:
-      { hostname: hostname, bunnymq: packageVersion, startedAt: startedAt, connectedAt: new Date() }
+      { hostname: hostname, bunnymq: packageVersion, startedAt: startedAt.toISOString(), connectedAt: new Date().toISOString() }
     }).then((conn) => {
         //on connection close, delete connection
         conn.on('close', () => { delete connection.conn; });

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -41,7 +41,7 @@ function consume (queue, options, callback) {
 
   //consumer gets a suffix if one is set on the configuration, to suffix all queues names
   //ex: service-something with suffix :ci becomes service-suffix:ci etc.
-  queue += this.conn.config.consumerSuffix;
+  var suffixedQueue = queue + this.conn.config.consumerSuffix;
 
   return this.conn.get()
   .then((_channel) => {
@@ -52,7 +52,7 @@ function consume (queue, options, callback) {
       consume.call(this, queue, options, callback);
     });
 
-    return this.channel.assertQueue(queue, options)
+    return this.channel.assertQueue(suffixedQueue, options)
     .then((_queue) => {
 
       this.conn.config.transport.info('bmq:consumer', 'init', _queue.queue);

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -61,7 +61,7 @@ function maybeAnswer(queue) {
       this.conn.config.transport.info('bmq:producer', '[' + queue + '] < answer');
       delete rpcQueue[corrId];
     } catch(e) {
-      this.conn.config.transport.error(e);
+      this.conn.config.transport.error(new Error('Receiving RPC message from previous session: callback no more in memory. ' + queue));
     }
   };
 }


### PR DESCRIPTION
# Fixes
- Pass string in clientProperties instead of objects (failing in amqp.node latest versions)
# Improvements
- Better logging message when intercepting RPC response when callback is empty (service restart)

For review @jkernech 
