### PR TITLE
Parse the provided prefetch to ensure it is an integer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ module.exports = function(config) {
     transport: utils.emptyLogger
   }, config);
 
+  config.prefetch = parseInt(config.prefetch, 10) || 0;
+
   return {
     producer: require('./modules/producer')(conn(config)),
     consumer: require('./modules/consumer')(conn(config))

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -70,5 +70,20 @@ describe('config', function() {
       var conf = { host: 'amqp://my-host' };
       assert.equal(main(conf).producer.conn.config.hostname.length, uuid.v4().length);
     });
+
+    it('should ensure prefetch is in an integer format', function() {
+      var conf = { host: 'amqp://my-host', prefetch: '3' };
+      assert.equal(main(conf).producer.conn.config.prefetch, 3);
+    });
+
+    it('should set unlimited prefetch if prefetch is an invalid value', function() {
+      var conf = { host: 'amqp://my-host', prefetch: '' };
+      assert.equal(main(conf).producer.conn.config.prefetch, 0);
+    });
+
+    it('should use provided prefetch', function() {
+      var conf = { host: 'amqp://my-host', prefetch: 1 };
+      assert.equal(main(conf).producer.conn.config.prefetch, 1);
+    });
   });
 });


### PR DESCRIPTION
Will be useful in our services, to avoid to check for an env var, or handle fallback values, etc.

If prefetch is provided, we parse it to ensure it is an int and avoid any mistake (param from env var).

If prefetch is provided but is not a number (even in a string), we set unlimited prefetch as a fallback.

Reviewers: @jkernech @mrister 
