### PR TITLE
Docker commands are now awaited and docker errors are now logged

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "assert": "1.3.0",
+    "child-process-promise": "^2.2.0",
     "eslint": "^3.11.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -8,7 +8,7 @@ const utils = require('../src/modules/utils');
 describe('disconnections', function () {
   before(docker.start);
 
-  after(docker.stop);
+  after(docker.rm);
 
   describe('regular pub/sub', () => {
     const queue = 'disco:test';

--- a/test/docker.js
+++ b/test/docker.js
@@ -1,14 +1,7 @@
-const exec = require('child_process').exec;
-const utils = require('../src/modules/utils');
+const exec = require('child-process-promise').exec;
 
-exec('docker rm rabbitmq-bunnymq');
+module.exports.start = () => exec('docker run -d --name=rabbitmq-bunnymq -p 5672:5672 rabbitmq:3.6; true && ' +
+                                  'docker start rabbitmq-bunnymq');
 
-module.exports.start = () => {
-  exec('docker run -d --name=rabbitmq-bunnymq -p 5672:5672 rabbitmq:3.6; true && docker start rabbitmq-bunnymq');
-  return utils.timeoutPromise(4500);
-};
-
-module.exports.stop = () => {
-  exec('docker stop rabbitmq-bunnymq');
-  return utils.timeoutPromise(1000);
-};
+module.exports.stop = () => exec('docker stop rabbitmq-bunnymq');
+module.exports.rm = () => exec('docker rm -f rabbitmq-bunnymq');

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -17,7 +17,7 @@ let letters = 0;
 describe('producer/consumer', function () {
   before(docker.start);
 
-  after(docker.stop);
+  after(docker.rm);
 
   describe('msg delevering', () => {
     before(() =>

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -14,7 +14,7 @@ const fixtures = {
 describe('Producer/Consumer RPC messaging:', function () {
   before(docker.start);
 
-  after(docker.stop);
+  after(docker.rm);
 
   it('should be able to create a consumer that returns a message if called as RPC [rpc-queue-0]', () =>
     consumer.consume(fixtures.queues[0], () =>


### PR DESCRIPTION
Fixes #74 by promisifying and awaiting the  `exec` commands resulting in error logging.

Also speeds up testing by about 8 seconds (from 27 to 19 seconds) on my VM because of two reasons:
- Docker commands are now awaited while they're executed, not for an arbitrary 4.5 or 1 second.
- The docker instance is now removed forcefully after each of the 3 tests. Before this PR, the docker instance was stopped gracefully and removed afterwards. Graceful stopping is unnecessary because it's removed anyways. :)