### PR TITLE
Move node-uuid:1.4.7 to uuid:3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@dialonce/boot": "^0.4.1",
     "amqplib": "^0.4.1",
     "dotenv": "^2.0.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "assert": "1.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 require('dotenv').config({ silent: true });
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const utils = require('./modules/utils');
 const connection = require('./modules/connection');
 const retrocompat = require('./modules/retrocompat-config');

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -1,5 +1,5 @@
 const utils = require('./utils');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const parsers = require('./message-parsers');
 const Deferred = require('../classes/deferred');
 

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -1,6 +1,6 @@
 require('dotenv').config({ silent: true });
 const assert = require('assert');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 require('@dialonce/boot')({
   LOGS_TOKEN: process.env.LOGS_TOKEN,
   BUGS_TOKEN: process.env.BUGS_TOKEN

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const bunnymq = require('../src/index')();
 const utils = require('../src/modules/utils');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const docker = require('./docker');
 
 const fixtures = {

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const bunnymq = require('../src/index')();
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const docker = require('./docker');
 const utils = require('../src/modules/utils');
 


### PR DESCRIPTION
This PR upgrade's the package `node-uuid@1.4.7` to `uuid@3.0.1`.
`uuid@3.0.1` should be a direct replacement to `node-uuid@1.4.7` as the api usage inside the project remains the same.

The major advantage would the removal of the warning given out by npm/yarn during install of bunnymq
```
warning bunnymq > node-uuid@1.4.7: use uuid module instead
```