### PR TITLE
Fix undefined queue name

### DIFF
--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -61,7 +61,7 @@ class Consumer {
 
     // consumer gets a suffix if one is set on the configuration, to suffix all queues names
     // ex: service-something with suffix :ci becomes service-suffix:ci etc.
-    const suffixedQueue = queue + this._connection.config.consumerSuffix;
+    const suffixedQueue = `${queue}${this._connection.config.consumerSuffix || ''}`;
 
     return this._connection.get()
     .then((channel) => {

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -141,4 +141,17 @@ describe('producer/consumer', function () {
       });
     });
   });
+
+  describe('undefined queue name', () => {
+    before(() => {
+      bunnymq.connection._config.consumerSuffix = undefined;
+    });
+
+    it('should receive message', () => {
+      bunnymq.consume('queue-name-undefined-suffix', (message) => {
+        assert.equal(message.msg, 'test for undefined queue suffix');
+      })
+        .then(() => bunnymq.produce('queue-name-undefined-suffix', { msg: 'test for undefined queue suffix' }));
+    });
+  });
 });


### PR DESCRIPTION
Changed the way suffixedQueue was defined in order to avoid undefined queue name.