### PR TITLE
Fix requeuing issue when buffer is full

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,6 @@
     // disable requiring trailing commas
     "comma-dangle": 0,
     "max-len": ["error", {"code": 120, "ignoreComments": true, "ignoreUrls": true}],
-    "no-underscore-dangle": [1, { "allow": ["_config"] }]
+    "no-underscore-dangle": [1, { "allow": ["_config", "_connection", "_maxListeners"] }]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = (config) => {
     //  time between two reconnect (ms)
     timeout: 1000,
     //  default timeout for RPC calls. If set to '0' there will be none.
-    rpcTimeout: 1000,
+    rpcTimeout: 15000,
     consumerSuffix: '',
     // generate a hostname so we can track this connection on the broker (rabbitmq management plugin)
     hostname: process.env.HOSTNAME || process.env.USER || uuid.v4(),

--- a/src/modules/bunnymq.js
+++ b/src/modules/bunnymq.js
@@ -48,11 +48,24 @@ module.exports = (connection) => {
   } else {
     instance.connection = connection;
   }
-  return {
+
+  const consumer = {
     consume: instance.consume.bind(instance),
-    subscribe: instance.subscribe.bind(instance),
+    subscribe: instance.subscribe.bind(instance)
+  };
+
+  const producer = {
     produce: instance.produce.bind(instance),
-    publish: instance.publish.bind(instance),
-    connection: instance.connection
+    publish: instance.publish.bind(instance)
+  };
+
+  return {
+    connection: instance.connection,
+    consume: consumer.consume,
+    subscribe: consumer.subscribe,
+    produce: producer.produce,
+    publish: producer.publish,
+    consumer,
+    producer
   };
 };

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -92,7 +92,7 @@ describe('config', () => {
 
     it('should use default rpcRimeout if none given', () => {
       const conf = { host: 'amqp://localhost' };
-      assert.equal(main(conf).connection.config.rpcTimeout, 1000);
+      assert.equal(main(conf).connection.config.rpcTimeout, 15000);
     });
 
     it('should use provided rpcRimeout', () => {

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -15,19 +15,19 @@ describe('disconnections', function () {
 
     it('should be able to re-register to consume messages between connection failures', (done) => {
       let counter = 0;
-      bunnymq.consume(queue, () => {
+      bunnymq.consumer.consume(queue, () => {
         counter += 1;
         if (counter === 50) {
           done();
         }
       })
-      .then(() => bunnymq.produce(queue))
+      .then(() => bunnymq.producer.produce(queue))
       .then(() => utils.timeoutPromise(500))
       .then(() => assert(counter))
       .then(docker.stop)
       .then(() => {
         for (let i = counter; i < 50; i += 1) {
-          bunnymq.produce(queue);
+          bunnymq.producer.produce(queue);
         }
       })
       .then(docker.start);
@@ -43,17 +43,17 @@ describe('disconnections', function () {
         if (cnt === 50) done();
       };
       bunnymq.connection._config.rpcTimeout = 0;
-      bunnymq.consume(queue, () => {
+      bunnymq.consumer.consume(queue, () => {
         counter += 1;
         return counter;
       })
-      .then(() => bunnymq.produce(queue, undefined, { rpc: true }).then(checkReceived))
+      .then(() => bunnymq.producer.produce(queue, undefined, { rpc: true }).then(checkReceived))
       .then(() => utils.timeoutPromise(500))
       .then(() => assert(counter))
       .then(docker.stop)
       .then(() => {
         for (let i = counter; i < 50; i += 1) {
-          bunnymq.produce(queue, undefined, { rpc: true }).then(checkReceived);
+          bunnymq.producer.produce(queue, undefined, { rpc: true }).then(checkReceived);
         }
       })
       .then(docker.start);

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -8,15 +8,13 @@ const fixtures = {
   queues: ['rpc-queue-0', 'rpc-queue-1', 'rpc-queue-2']
 };
 
-/* eslint func-names: "off" */
-/* eslint prefer-arrow-callback: "off" */
-describe('Producer/Consumer RPC messaging:', function () {
+describe('Producer/Consumer RPC messaging:', () => {
   before(docker.start);
 
   after(docker.rm);
 
   it('should be able to create a consumer that returns a message if called as RPC [rpc-queue-0]', () =>
-    bunnymq.consume(fixtures.queues[0], () =>
+    bunnymq.consumer.consume(fixtures.queues[0], () =>
       'Power Ranger Red'
     )
     .then((created) => {
@@ -25,29 +23,25 @@ describe('Producer/Consumer RPC messaging:', function () {
   );
 
   it('should be able to send directly to the queue, without correlationId and not crash [rpc-queue-0]', () =>
-    bunnymq.produce(fixtures.queues[0], { nothing: true }, { rpc: true })
+    bunnymq.producer.produce(fixtures.queues[0], { nothing: true }, { rpc: true })
       .then(() =>
-        bunnymq.produce(`${fixtures.queues[0]}:${bunnymq.connection.config.hostname}:res`, { nothing: true })
+        bunnymq.producer.produce(`${fixtures.queues[0]}:${bunnymq.connection.config.hostname}:res`, { nothing: true })
       )
       .then(utils.timeoutPromise(500))
   );
 
   it('should be able to produce a RPC message and get a response [rpc-queue-0]', () =>
-    bunnymq.produce(fixtures.queues[0], { msg: uuid.v4() }, { rpc: true })
+    bunnymq.producer.produce(fixtures.queues[0], { msg: uuid.v4() }, { rpc: true })
     .then((response) => {
       assert.equal(response, 'Power Ranger Red');
     })
   );
 
-  /* eslint no-labels: "off" */
-  /* eslint no-restricted-syntax: "off" */
-  /* eslint no-unused-labels: "off" */
-  /* eslint no-unused-expressions: "off" */
   it('should be able to produce a RPC message and get a as JSON [rpc-queue-1]', () =>
-    bunnymq.consume(fixtures.queues[1],
+    bunnymq.consumer.consume(fixtures.queues[1],
       () => Object.assign({}, { powerRangerColor: 'Pink' }))
     .then(() =>
-      bunnymq.produce(fixtures.queues[1], { msg: uuid.v4() }, { rpc: true })
+      bunnymq.producer.produce(fixtures.queues[1], { msg: uuid.v4() }, { rpc: true })
     )
     .then((response) => {
       assert.equal(typeof response, 'object');
@@ -56,8 +50,8 @@ describe('Producer/Consumer RPC messaging:', function () {
   );
 
   it('should be able to produce a RPC message and get undefined response [rpc-queue-2]', () =>
-    bunnymq.consume(fixtures.queues[2], () => undefined)
-    .then(() => bunnymq.produce(fixtures.queues[2], undefined, { rpc: true }))
+    bunnymq.consumer.consume(fixtures.queues[2], () => undefined)
+    .then(() => bunnymq.producer.produce(fixtures.queues[2], undefined, { rpc: true }))
     .then((response) => {
       assert(response === undefined, 'Got a response !== undefined');
     })


### PR DESCRIPTION
This is a fix for when the function `publishOrSendToQueue` return false which means that the buffer is full.
But after testing it, i noticed that even if the function return false, the message still get published to the broker. So for the fix i removed this logic to avoid message duplication. 