### PR TITLE
Remove @dialonce/boot module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ You can specify a config object, properties and default values are:
 
 You can override any or no of the property above.
 
+<b>Note:</b> if you enable the debug mode using the `AMQP_DEBUG=true` env var, but you do not attach any transport logger, the module will fallback to console.
+
 ## Env vars
 Deprecated as of 2.1.0, don't use env vars to configure the module, see Config section.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/dial-once/node-bunnymq#readme",
   "dependencies": {
-    "@dialonce/boot": "^0.4.1",
     "amqplib": "^0.4.1",
     "deserialize-error": "0.0.3",
     "dotenv": "^2.0.0",

--- a/samples/areas/consumer.js
+++ b/samples/areas/consumer.js
@@ -1,5 +1,5 @@
+/* eslint no-console: off */
 const consumer = require('../../src/index')().consumer;
-const { logger } = require('@dialonce/boot')();
 
 /* eslint no-param-reassign: "off" */
 consumer.consume('circleArea', (msg) => {
@@ -7,7 +7,7 @@ consumer.consume('circleArea', (msg) => {
 
   const area = (parseInt(msg.r, 10) ** 2) * Math.PI;
 
-  logger.info('Circle area is: ', area);
+  console.info('Circle area is: ', area);
 
   return area;
 });
@@ -17,7 +17,7 @@ consumer.consume('squareArea', (msg) => {
 
   const area = parseInt(msg.l, 10) ** 2;
 
-  logger.info('Square area is: ', area);
+  console.info('Square area is: ', area);
 
   return area;
 });
@@ -27,7 +27,7 @@ consumer.consume('triangleArea', (msg) => {
 
   const area = parseInt(msg.b, 10) * parseInt(msg.h, 10) * 0.5;
 
-  logger.info('Triangle area is: ', area);
+  console.info('Triangle area is: ', area);
 
   return area;
 });

--- a/samples/hello-world/consumer.js
+++ b/samples/hello-world/consumer.js
@@ -1,5 +1,5 @@
+/* eslint no-console: off */
 const consumer = require('../../src/index')().consumer;
-const { logger } = require('@dialonce/boot')();
 
 consumer.connect()
 .then(() => {
@@ -8,5 +8,5 @@ consumer.connect()
       setTimeout(resolve(true), 5000);
     })
   )
-  .then(logger.info); // true if message has been acknowledged, else false
+  .then(console.info); // true if message has been acknowledged, else false
 });

--- a/samples/hello-world/producer.js
+++ b/samples/hello-world/producer.js
@@ -1,8 +1,8 @@
+/* eslint no-console: off */
 const producer = require('../../src/index')().producer;
-const { logger } = require('@dialonce/boot')();
 
 producer.connect()
 .then(() => {
   producer.produce('queueName', { message: 'hello world!' })
-  .then(logger.info); // true if message has been sent, else false
+  .then(console.info); // true if message has been sent, else false
 });

--- a/samples/prefetch/producer.js
+++ b/samples/prefetch/producer.js
@@ -1,12 +1,12 @@
+/* eslint no-console: off */
 const producer = require('../../src/index')().producer;
-const { logger } = require('@dialonce/boot')();
 
 let i = 0;
 let interval;
 
 interval = setInterval(() => {
   producer.produce(`queue-prefetch${i}`, { message: `start-${i}` }, { rpc: true })
-  .then(logger.info);
+  .then(console.info);
 
   i += 1;
   if (i >= 100) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,6 @@ const uuid = require('uuid');
 const utils = require('./modules/utils');
 const connection = require('./modules/connection');
 const retrocompat = require('./modules/retrocompat-config');
-require('@dialonce/boot')({
-  LOGS_TOKEN: process.env.LOGS_TOKEN,
-  BUGS_TOKEN: process.env.BUGS_TOKEN
-});
 
 require('events').EventEmitter.prototype._maxListeners = process.env.MAX_EMITTERS || 20;
 

--- a/src/modules/retrocompat-config.js
+++ b/src/modules/retrocompat-config.js
@@ -1,6 +1,4 @@
-const { logger } = require('@dialonce/boot')();
 // deprecated configuration property names
-/* eslint global-require: "off" */
 function oldConfigNames(config) {
   const configuration = Object.assign({}, config);
   if (configuration.amqpUrl) {
@@ -32,13 +30,10 @@ function envVars(config) {
     configuration.consumerSuffix = process.env.LOCAL_QUEUE;
   }
 
-  if (process.env.AMQP_DEBUG) {
-    try {
-      configuration.transport = logger;
-    } catch (e) {
-      configuration.transport = console;
-    }
+  if (process.env.AMQP_DEBUG && !configuration.transport) {
+    configuration.transport = console;
   }
+
   return configuration;
 }
 

--- a/test/config-spec.js
+++ b/test/config-spec.js
@@ -1,10 +1,6 @@
 require('dotenv').config({ silent: true });
 const assert = require('assert');
 const uuid = require('uuid');
-require('@dialonce/boot')({
-  LOGS_TOKEN: process.env.LOGS_TOKEN,
-  BUGS_TOKEN: process.env.BUGS_TOKEN
-});
 
 /* eslint global-require: "off" */
 describe('config', () => {


### PR DESCRIPTION
I removed the `@dialonce/boot` because:
- Since bunnymq is an opensource module, we should let the user choose its transport
- It was causing an issue when i tested it on one of our projects

