### PR TITLE
Allow string messages to be passed to produce and not only objects

### DIFF
--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -163,7 +163,7 @@ class Producer {
   /**
    * Ensure channel exists and send message using `checkRpc`
    * @param  {string} queue   The destination queue on which we want to send a message
-   * @param  {any} msg     Anything serializable/bufferable
+   * @param  {string|object} msg     Anything serializable/bufferable
    * @param  {object} options message options (persistent, durable, rpc, etc.)
    * @return {Promise}         checkRpc response
    */
@@ -172,7 +172,7 @@ class Producer {
     // default options are persistent and durable because we do not want to miss any outgoing message
     // unless user specify it
     const settings = Object.assign({ persistent: true, durable: true }, options);
-    let message = Object.assign({}, msg);
+    let message = typeof msg === 'string' ? msg : Object.assign({}, msg);
     return this._connection.get()
     .then((channel) => {
       this.channel = channel;

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -29,28 +29,37 @@ describe('producer/consumer', function () {
       )
     );
 
-    it('should be able to consume message sended by producer to queue [test-queue-0]', () => {
+    it('should receive message that is only string', () => {
+      const queueName = 'test-only-string-queue';
+      return bunnymq.consumer.consume(queueName, message => Promise.resolve(`${message}-test`))
+      .then(() => bunnymq.producer.produce(queueName, '85.69.30.121', { rpc: true }))
+      .then((result) => {
+        assert.equal(result, '85.69.30.121-test');
+      });
+    });
+
+    it('should be able to consume message sent by producer to queue [test-queue-0]', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[0], { msg: uuid.v4() })
         .then(() => utils.timeoutPromise(300))
         .then(() => assert.equal(letters, 0));
     });
 
-    it('should be able to consume message sended by producer to queue [test-queue-0] (no message)', () => {
+    it('should be able to consume message sent by producer to queue [test-queue-0] (no message)', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[0])
         .then(() => utils.timeoutPromise(300))
         .then(() => assert.equal(letters, 0));
     });
 
-    it('should be able to consume message sended by producer to queue [test-queue-0] (null message)', () => {
+    it('should be able to consume message sent by producer to queue [test-queue-0] (null message)', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[0], null)
         .then(() => utils.timeoutPromise(300))
         .then(() => assert.equal(letters, 0));
     });
 
-    it('should not be able to consume message sended by producer to queue [test-queue-1]', () => {
+    it('should not be able to consume message sent by producer to queue [test-queue-1]', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[1], null)
         .then(() => utils.timeoutPromise(300))


### PR DESCRIPTION
Fix to allow string messages to be passed and not only objects to produce

Object.assign({}, message) is used internally to transform the message,
but if the message is a string this will mangle it and turn into an object (Eg for "test" it wil become {0: "t", 1: "e", 2: "s", 3: "t"}) and this was causing problems in some of our services.
Fix is to check if message is a string and not process with Object.assign if it is. Also added test.