### PR TITLE
Fix wrong serialisation of arrays

### DIFF
--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -172,7 +172,14 @@ class Producer {
     // default options are persistent and durable because we do not want to miss any outgoing message
     // unless user specify it
     const settings = Object.assign({ persistent: true, durable: true }, options);
-    let message = typeof msg === 'string' ? msg : Object.assign({}, msg);
+
+    let message = msg;
+    if (Array.isArray(msg)) {
+      message = Object.assign([], msg);
+    } else if (typeof(msg) !== 'string') {
+      message = Object.assign({}, msg);
+    }
+
     return this._connection.get()
     .then((channel) => {
       this.channel = channel;

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -38,6 +38,15 @@ describe('producer/consumer', function () {
       });
     });
 
+    it('should receive message that is only array', () => {
+      const queueName = 'test-only-array-queue';
+      return bunnymq.consumer.consume(queueName, message => Promise.resolve({ message }))
+      .then(() => bunnymq.producer.produce(queueName, [1, '2'], { rpc: true }))
+      .then((result) => {
+        assert.deepEqual(result, { message: [1, '2'] });
+      });
+    });
+
     it('should be able to consume message sent by producer to queue [test-queue-0]', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[0], { msg: uuid.v4() })


### PR DESCRIPTION
When doing publish of array, like this:

```
bunnymq.publish('queue:name', [{ message: 'content' }], { rpc: true, timeout: 1000 })
```

Payload is: `{"0":{"message":"content"}}`
This commit handle special check to make sure payload to be: `[{"message":"content"}]`


Fixes https://github.com/dial-once/node-bunnymq/issues/97