### PR TITLE
Exposed amqplib message properties to the consumer. 

### DIFF
--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -82,7 +82,7 @@ class Consumer {
           // main answer management chaining
           // receive message, parse it, execute callback, check if should answer, ack/reject message
           Promise.resolve(parsers.in(msg))
-          .then(callback)
+          .then(body => callback(body, msg.properties))
           .then(this.checkRpc(msg, q.queue))
           .then(() => {
             this.channel.ack(msg);

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -49,13 +49,13 @@ describe('producer/consumer', function () {
 
 
     it('should receive message headers', () => {
-      const header =  {header1: "Header1", header2: "Header2"};
+      const headers =  {header1: "Header1", header2: "Header2"};
       const queueName = 'test-headers';
       return bunnymq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message: message, properties: properties }))
-      .then(() => bunnymq.producer.produce(queueName, [1, '2'], { rpc: true, headers: header }))
+      .then(() => bunnymq.producer.produce(queueName, [1, '2'], { rpc: true, headers: headers }))
       .then((result) => {
         assert.deepEqual(result.message, [1, '2']);
-        assert.deepEqual(result.properties.headers, header);
+        assert.deepEqual(result.properties.headers, headers);
       });
     });
 

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -47,6 +47,29 @@ describe('producer/consumer', function () {
       });
     });
 
+
+    it('should receive message headers', () => {
+      const header =  {header1: "Header1", header2: "Header2"};
+      const queueName = 'test-headers';
+      return bunnymq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message: message, properties: properties }))
+      .then(() => bunnymq.producer.produce(queueName, [1, '2'], { rpc: true, headers: header }))
+      .then((result) => {
+        assert.deepEqual(result.message, [1, '2']);
+        assert.deepEqual(result.properties.headers, header);
+      });
+    });
+
+
+    it('should receive message properties', () => {
+      const queueName = 'test-headers';
+      return bunnymq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message: message, properties: properties }))
+      .then(() => bunnymq.producer.produce(queueName, [1, '2'], { rpc: true }))
+      .then((result) => {
+        assert.deepEqual(result.message, [1, '2']);
+        assert.deepEqual(result.properties.contentType,  "application/json");
+      });
+    });
+
     it('should be able to consume message sent by producer to queue [test-queue-0]', () => {
       letters += 1;
       return bunnymq.producer.produce(fixtures.queues[0], { msg: uuid.v4() })


### PR DESCRIPTION
The consumer should have access to the message properties and specifically to be able to read headers.